### PR TITLE
Fixes "canonical" name when multiple aliases are added.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function mapRoute(routePath, name) {
         names       = ((annotations && annotations.names) || []).concat(name);
 
     name = (annotations && annotations.name) ||
-            Array.isArray(name) ? name[0] : name;
+            (Array.isArray(name) ? name[0] : name);
 
     return this.annotate(routePath, {
         // Annotate with a singular name, either existing or new.

--- a/tests/unit/map-test.js
+++ b/tests/unit/map-test.js
@@ -29,6 +29,14 @@ describe('test suite name', function () {
 
             assert.isObject(app.params);
         });
+        it('should extend with multiple names', function () {
+
+            app.map('/foo', 'foo');
+            app.map('/foo', 'get#foo');
+
+            assert.strictEqual('foo', app.annotations['/foo'].name, 'wrong name');
+            assert.strictEqual(2, app.annotations['/foo'].names.length, 'wrong # of names');
+        });
     });
 
 });


### PR DESCRIPTION
This fixes the use case where multiple aliases are added to a known path where the "canonical" name was getting incorrectly truncated.

Unit test included.
