### PR TITLE
Use express-extend to extend Express apps

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,17 @@
 'use strict';
 
-var annotations = require('express-annotations'),
-    methods     = require('methods'),
+var annotations   = require('express-annotations'),
+    extendExpress = require('express-extend'),
+    methods       = require('methods'),
 
     pathTo = require('./lib/pathto');
 
-exports.extend = extendApp;
+exports.extend = extendExpress('@map', exports, extendApp);
 exports.pathTo = pathTo;
 
 function extendApp(app) {
-    if (app['@map']) { return app; }
-
     // Add Express Annotations support to the `app`.
     annotations.extend(app);
-
-    // Brand.
-    Object.defineProperty(app, '@map', {value: true});
 
     app.map            = mapRoute;
     app.getRouteMap    = getRouteMap;
@@ -26,8 +22,6 @@ function extendApp(app) {
     // exposed along with the exposed routes.
     app.params = {};
     app.param(registerParam.bind(app));
-
-    return app;
 }
 
 // TODO: Should this accept an object of mappings? If so what should be the key,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "dependencies": {
     "express-annotations": "~0.0.1",
+    "express-extend": "0.0.1",
     "methods": "~0.0.1"
   },
   "peerDependencies": {
@@ -36,7 +37,7 @@
   },
   "repository": {
     "type": "git",
-    "url" : "git://github.com/yahoo/express-map.git"
+    "url": "git://github.com/yahoo/express-map.git"
   },
   "bugs": {
     "url": "https://github.com/yahoo/express-map/issues"


### PR DESCRIPTION
I created a new package: [ericf/express-extend](https://github.com/ericf/express-extend) for applying the branding pattern to extending Express apps and this PR uses it. Let me know what you think.

/cc @caridy 
