### PR TITLE
Wrap `pathTo()` with UMD+YUI module registration wrapper

### DIFF
--- a/lib/pathto.js
+++ b/lib/pathto.js
@@ -25,7 +25,7 @@ See the accompanying LICENSE file for terms.
         inModuleSystem = true;
     }
 
-    if (typeof YUI === 'function' && YUI.add) {
+    if (typeof YUI !== 'undefined' && YUI.add) {
         YUI.add('pathto', factory, '0.1.0', {es: true});
         inModuleSystem = true;
     }


### PR DESCRIPTION
This adds the UMD+YUI wrapper around the `pathTo()` function so it can be served to the browser and it will self-register in JavaScript module systems.

I choose to use the `else if` pattern because this module is closely coupled with your app code, therefore it doesn't seem practical that there would be more than one module system that needs access to this code.
### Todos
- [x] Get code review
- [x] Answer whether this should be in its own package
- [ ] Add `HISTORY.md` entry
- [ ] Figured out how to get Istanbul ignore UMD+YUI wrapper
